### PR TITLE
Bug fixes in vector implementation

### DIFF
--- a/rssnews/vector.c
+++ b/rssnews/vector.c
@@ -60,7 +60,7 @@ void VectorReplace(vector *v, const void *elemAddr, int position)
 }
 
 void VectorGrow(vector *v) {
-	v->allocatedLength += (v->allocationChunk * v->elemSize);
+	v->allocatedLength += v->allocationChunk;
 	v->elems = realloc(v->elems, v->allocatedLength * v->elemSize);
 }
 

--- a/rssnews/vector.c
+++ b/rssnews/vector.c
@@ -100,6 +100,9 @@ void VectorDelete(vector *v, int position)
 
 	//int checkElems = VectorLength(v);
 
+	if (v->freeFn != NULL)
+		v->freeFn(VectorNth(v, position));
+
 	v->logicalLength--;
 
 	// if not at the end, need to move the list up by one

--- a/rssnews/vector.c
+++ b/rssnews/vector.c
@@ -8,13 +8,12 @@ void VectorNew(vector *v, int elemSize, VectorFreeFunction freeFn, int initialAl
 {
 	assert(v != NULL);
 	v->logicalLength = 0;
+
+	if (initialAllocation == 0)
+		initialAllocation = 10;
+
 	v->allocatedLength = initialAllocation;
-
-	if (initialAllocation != 0)
-		v->allocationChunk = initialAllocation;	
-	else	
-		v->allocationChunk = 10;
-
+	v->allocationChunk = initialAllocation;
 	v->elemSize = elemSize;
 	v->elems = malloc(initialAllocation * elemSize);
 	v->freeFn = freeFn;

--- a/rssnews/vector.c
+++ b/rssnews/vector.c
@@ -106,7 +106,7 @@ void VectorDelete(vector *v, int position)
 	if (position != v->logicalLength) {
 		void *moveTo = (char *)v->elems + (position * v->elemSize);
 		void *moveFrom = (char *)moveTo + v->elemSize;
-		memcpy(moveTo, moveFrom, (v->logicalLength - position) * v->elemSize);
+		memmove(moveTo, moveFrom, (v->logicalLength - position) * v->elemSize);
 	}
 	//checkElems = VectorLength(v);
 	

--- a/rssnews/vector.c
+++ b/rssnews/vector.c
@@ -56,6 +56,9 @@ void VectorReplace(vector *v, const void *elemAddr, int position)
 
 	void *target = (char *)v->elems + (position * v->elemSize);
 
+	if (v->freeFn != NULL)
+		v->freeFn(target);
+
 	memcpy(target, elemAddr, v->elemSize);
 }
 

--- a/thread_107/vector2.c
+++ b/thread_107/vector2.c
@@ -104,7 +104,7 @@ void VectorDelete2(vector2 *v, int position)
 	if (position != v->logicalLength) {
 		void *moveTo = (char *)v->elems + (position * v->elemSize);
 		void *moveFrom = (char *)moveTo + v->elemSize;
-		memcpy(moveTo, moveFrom, (v->logicalLength - position) * v->elemSize);
+		memmove(moveTo, moveFrom, (v->logicalLength - position) * v->elemSize);
 	}
 }
 

--- a/thread_107/vector2.c
+++ b/thread_107/vector2.c
@@ -98,6 +98,9 @@ void VectorDelete2(vector2 *v, int position)
 {
 	assert((v != NULL) && (position >=0 ) && (position < v->logicalLength));
 
+	if (v->freeFn != NULL)
+		v->freeFn(VectorNth2(v, position));
+
 	v->logicalLength--;
 
 	// if not at the end, need to move the list up by one

--- a/thread_107/vector2.c
+++ b/thread_107/vector2.c
@@ -56,6 +56,9 @@ void VectorReplace2(vector2 *v, const void *elemAddr, int position)
 
 	void *target = (char *)v->elems + (position * v->elemSize);
 
+	if (v->freeFn != NULL)
+		v->freeFn(target);
+
 	memcpy(target, elemAddr, v->elemSize);
 }
 

--- a/thread_107/vector2.c
+++ b/thread_107/vector2.c
@@ -60,7 +60,7 @@ void VectorReplace2(vector2 *v, const void *elemAddr, int position)
 }
 
 void VectorGrow2(vector2 *v) {
-	v->allocatedLength += (v->allocationChunk * v->elemSize);
+	v->allocatedLength += v->allocationChunk;
 	v->elems = realloc(v->elems, v->allocatedLength * v->elemSize);
 }
 

--- a/thread_107/vector2.c
+++ b/thread_107/vector2.c
@@ -8,13 +8,12 @@ void VectorNew2(vector2 *v, int elemSize, VectorFreeFunction2 freeFn, int initia
 {
 	assert(v != NULL);
 	v->logicalLength = 0;
+
+	if (initialAllocation == 0)
+		initialAllocation = 10;
+
 	v->allocatedLength = initialAllocation;
-
-	if (initialAllocation != 0)
-		v->allocationChunk = initialAllocation;	
-	else	
-		v->allocationChunk = 10;
-
+	v->allocationChunk = initialAllocation;
 	v->elemSize = elemSize;
 	v->elems = malloc(initialAllocation * elemSize);
 	v->freeFn = freeFn;


### PR DESCRIPTION
Hi, first of all I want to thank you for making and sharing this code. It has really helped me to be able to run the code for assignments 4 and 6.

I fixed some bugs and problems that I found while using the vector implementation:

- In `VectorNew`, when the user passed 0 for `initialAllocation`, the default value (10) was only used for `allocationChunk` but not for `allocatedLength`. I made some changes to fix that.
- `allocatedLength` should store the number of elements, not the size (it is already multiplied by `elemSize` when calling `realloc`). So, in `VectorGrow`, it should only be incremented by `allocationChunk`.
- In `VectorDelete`, `moveTo` and `moveFrom` might overlap, so `memmove` should be used instead of `memcpy`.
- In `VectorDelete` and `VectorReplace`, the supplied `VectorFreeFunction` should be called, as the specification says.