### PR TITLE
Avoid segmentation fault in URLConnectionDispose

### DIFF
--- a/rssnews/urlconnection.c
+++ b/rssnews/urlconnection.c
@@ -224,6 +224,7 @@ void URLConnectionDispose(urlconnection* urlconn)
   }
 */
   if (DEBUG_URLCONN) printf(" .. closing dataStream\n");
-  fclose(urlconn->dataStream);
+  if (urlconn->responseCode != 0)
+    fclose(urlconn->dataStream);
   if (DEBUG_URLCONN) printf("freed up URL Connection\n");
 }


### PR DESCRIPTION
There was a segmentation fault in `URLConnectionDispose` when calling `fclose` if `curl_easy_perform` fails and `responseCode` is 0.