### PR TITLE
Include fcntl.h (needed for O_CREAT and O_EXCL)

### DIFF
--- a/thread_107/thread_107.c
+++ b/thread_107/thread_107.c
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <sys/errno.h>
+#include <fcntl.h>
 #include "vector2.h"
 #include "bool.h"
 


### PR DESCRIPTION
`fcntl.h` needs to be included for `O_CREAT` and `O_EXCL`.